### PR TITLE
Add message start check for power state detection

### DIFF
--- a/components/philips_series_2200/philips_series_2200.cpp
+++ b/components/philips_series_2200/philips_series_2200.cpp
@@ -28,7 +28,6 @@ namespace esphome
                 display_uart_.read_array(buffer, size);
 
                 mainboard_uart_.write_array(buffer, size);
-                last_message_from_display_time_ = millis();
             }
 
             // Read until start index
@@ -48,30 +47,33 @@ namespace esphome
 
                 display_uart_.write_array(buffer, size);
 
-                // Update status sensors
-                for (philips_status_sensor::StatusSensor *status_sensor : status_sensors_)
-                    status_sensor->update_status(buffer, size);
-            }
-
-            // Publish power state if required as long as the display is requesting messages
-            if (power_switches_.size() > 0)
-            {
-                if (millis() - last_message_from_display_time_ > POWER_STATE_TIMEOUT)
+                // Only process messages starting with start bytes
+                if (size > 1 && buffer[0] == 0xD5 && buffer[1] == 0x55)
                 {
-                    // Update power switches
-                    for (philips_power_switch::Power *power_switch : power_switches_)
-                        power_switch->publish_state(false);
+                    last_message_from_mainboard_time_ = millis();
 
                     // Update status sensors
                     for (philips_status_sensor::StatusSensor *status_sensor : status_sensors_)
-                        status_sensor->set_state_off();
+                        status_sensor->update_status(buffer, size);
                 }
-                else
-                {
-                    // Update power switches
-                    for (philips_power_switch::Power *power_switch : power_switches_)
-                        power_switch->publish_state(true);
-                }
+            }
+
+            // Publish power state if required as long as the display is requesting messages
+            if (millis() - last_message_from_mainboard_time_ > POWER_STATE_TIMEOUT)
+            {
+                // Update power switches
+                for (philips_power_switch::Power *power_switch : power_switches_)
+                    power_switch->publish_state(false);
+
+                // Update status sensors
+                for (philips_status_sensor::StatusSensor *status_sensor : status_sensors_)
+                    status_sensor->set_state_off();
+            }
+            else
+            {
+                // Update power switches
+                for (philips_power_switch::Power *power_switch : power_switches_)
+                    power_switch->publish_state(true);
             }
 
             display_uart_.flush();

--- a/components/philips_series_2200/philips_series_2200.h
+++ b/components/philips_series_2200/philips_series_2200.h
@@ -71,7 +71,7 @@ namespace esphome
             }
 
         private:
-            long last_message_from_display_time_ = 0;
+            long last_message_from_mainboard_time_ = 0;
 
             /// @brief reference to uart connected to the display unit
             uart::UARTDevice display_uart_;


### PR DESCRIPTION
This PR changes the behavior of power switches.
The state is now determined based on the presence of messages starting with 'D5:55' rather than on the presence of messages in general.
