### PR TITLE
Remove pin state reading

### DIFF
--- a/components/philips_power_switch/power.cpp
+++ b/components/philips_power_switch/power.cpp
@@ -18,7 +18,7 @@ namespace esphome
             {
                 if (should_power_trip_ && millis() - last_power_trip_ > power_trip_delay_ + POWER_TRIP_RETRY_DELAY)
                 {
-                    if (power_trip_count_ > MAX_POWER_TRIP_COUNT)
+                    if (power_trip_count_ >= MAX_POWER_TRIP_COUNT)
                     {
                         should_power_trip_ = false;
                         ESP_LOGE(TAG, "Power tripping display failed!");
@@ -26,9 +26,9 @@ namespace esphome
                     }
 
                     // Perform power trip (invert state twice)
-                    power_pin_->digital_write(!power_pin_->digital_read());
+                    power_pin_->digital_write(!(*initial_state_));
                     delay(power_trip_delay_);
-                    power_pin_->digital_write(!power_pin_->digital_read());
+                    power_pin_->digital_write(*initial_state_);
 
                     last_power_trip_ = millis();
                     power_trip_count_++;

--- a/components/philips_power_switch/power.h
+++ b/components/philips_power_switch/power.h
@@ -72,6 +72,16 @@ namespace esphome
                 }
 
                 /**
+                 * @brief Sets the initial state reference on this power switch
+                 *
+                 * @param initial_state hub components initial state reference
+                 */
+                void set_initial_state(bool *initial_state)
+                {
+                    initial_state_ = initial_state;
+                }
+
+                /**
                  * @brief Processes and publish the new switch state.
                  */
                 void update_state(bool state);
@@ -91,6 +101,8 @@ namespace esphome
                 long last_power_trip_ = 0;
                 /// @brief nr of power performed power trips
                 int power_trip_count_ = 0;
+                /// @brief initial power state reference
+                bool *initial_state_;
             };
 
         } // namespace power_switch

--- a/components/philips_series_2200/philips_series_2200.cpp
+++ b/components/philips_series_2200/philips_series_2200.cpp
@@ -14,7 +14,7 @@ namespace esphome
         {
             power_pin_->setup();
             power_pin_->pin_mode(gpio::FLAG_OUTPUT);
-            power_pin_->digital_write(!invert_);
+            power_pin_->digital_write(initial_pin_state_);
         }
 
         void PhilipsSeries2200::loop()

--- a/components/philips_series_2200/philips_series_2200.h
+++ b/components/philips_series_2200/philips_series_2200.h
@@ -48,7 +48,7 @@ namespace esphome
              */
             void set_invert_power_pin(bool invert)
             {
-                invert_ = invert;
+                initial_pin_state_ = !invert;
             }
 
             void set_power_trip_delay(uint32_t time)
@@ -67,6 +67,7 @@ namespace esphome
                 power_switch->set_mainboard_uart(&mainboard_uart_);
                 power_switch->set_power_pin(power_pin_);
                 power_switch->set_power_trip_delay(power_trip_delay_);
+                power_switch->set_initial_state(&initial_pin_state_);
                 power_switches_.push_back(power_switch);
             };
 
@@ -124,8 +125,8 @@ namespace esphome
             /// @brief pin connect to display panel power transistor/mosfet
             GPIOPin *power_pin_;
 
-            /// @brief indicates if the power pin should be inverted
-            bool invert_ = false;
+            /// @brief the initial power pin state (may be inverted through user configuration)
+            bool initial_pin_state_ = true;
 
             /// @brief length of power outage applied to the display
             uint32_t power_trip_delay_ = 500;


### PR DESCRIPTION
This PR removes the pin state reading for pin inversion, as it apparently only works on ESP8266 chips.
I was able to measure no state change on an ESP32. The fixed pin state version, based on the initial pin state, works as expected.

Close #24