### PR TITLE
Fix unreliable power-on on some machines

### DIFF
--- a/components/philips_series_2200/switch/power.cpp
+++ b/components/philips_series_2200/switch/power.cpp
@@ -40,20 +40,20 @@ namespace esphome
                 if (state)
                 {
                     // Send pre-power on message
-                    for (unsigned int i = 0; i <= MESSAGE_REPETITIONS; i++)
+                    for (unsigned int i = 0; i <= POWER_MESSAGE_REPETITIONS; i++)
                         mainboard_uart_->write_array(command_pre_power_on);
 
                     // Send power on message
                     if (cleaning_)
                     {
                         // Send power on command with cleaning
-                        for (unsigned int i = 0; i <= MESSAGE_REPETITIONS; i++)
+                        for (unsigned int i = 0; i <= POWER_MESSAGE_REPETITIONS; i++)
                             mainboard_uart_->write_array(command_power_with_cleaning);
                     }
                     else
                     {
                         // Send power on command without cleaning
-                        for (unsigned int i = 0; i <= MESSAGE_REPETITIONS; i++)
+                        for (unsigned int i = 0; i <= POWER_MESSAGE_REPETITIONS; i++)
                             mainboard_uart_->write_array(command_power_without_cleaning);
                     }
 
@@ -66,7 +66,7 @@ namespace esphome
                 else
                 {
                     // Send power off message
-                    for (unsigned int i = 0; i <= MESSAGE_REPETITIONS; i++)
+                    for (unsigned int i = 0; i <= POWER_MESSAGE_REPETITIONS; i++)
                         mainboard_uart_->write_array(command_power_off);
                     mainboard_uart_->flush();
                 }

--- a/components/philips_series_2200/switch/power.h
+++ b/components/philips_series_2200/switch/power.h
@@ -5,7 +5,7 @@
 #include "esphome/components/uart/uart.h"
 #include "../commands.h"
 
-#define MESSAGE_REPETITIONS 5
+#define POWER_MESSAGE_REPETITIONS 25
 #define POWER_TRIP_RETRY_DELAY 100
 #define MAX_POWER_TRIP_COUNT 5
 


### PR DESCRIPTION
This PR increases the message repetition count for power related messages. As mentioned in #19 and #30 this resolve a `powering on` issue on some machines. This change should have no side effects on other machines.

Close #30
Close #19 