### PR TITLE
Add localization and internationalization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A example configuration can be found [here](example.yaml)
 - **invert_power_pin**(**Optional**: boolean): If set to `true` the output of the power pin will be inverted. Defaults to `false`.
 - **power_trip_delay**(**Optional**: Time): Determines the length of the power outage applied to the display unit, which is to trick it into turning on. Defaults to `500ms`.
 - **power_message_repetitions**(**Optional**: uint): Determines how many message repetitions are used while turning on the machine. On some hardware combinations a higher value such as `25` is required to turn on the display successfully. Defaults to `5`.
+- **language**(**Optional**: int): Status sensor language. Select one of `en-US`, `de-DE`. Defaults to `en-US`.
 - **model**(**Optional**: int): Different models or revisions may use different commands. This option can be used to specify the command set used by this component. Select one of `EP_2220`, `EP_2235`, `EP_3243`, `EP_3246`. Defaults to `EP_2220`.
 
 ## Philips Power switch

--- a/components/philips_coffee_machine/__init__.py
+++ b/components/philips_coffee_machine/__init__.py
@@ -23,6 +23,13 @@ COMMAND_SETS = {
     "EP_3246": "PHILIPS_EP3243",
 }
 
+CONF_LANGUAGE = "language"
+# Using IETF BCP 47 language tags (RFC 5646)
+LANGUAGES = {
+    "en-US": "PHILIPS_COFFEE_LANG_en_US",
+    "de-DE": "PHILIPS_COFFEE_LANG_de_DE",
+}
+
 philips_coffee_machine_ns = cg.esphome_ns.namespace("philips_coffee_machine")
 PhilipsCoffeeMachine = philips_coffee_machine_ns.class_(
     "PhilipsCoffeeMachine", cg.Component
@@ -46,6 +53,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_COMMAND_SET, default="EP_2220"): cv.enum(
             COMMAND_SETS, upper=True, space="_"
         ),
+        cv.Optional(CONF_LANGUAGE, default="en-US"): cv.enum(LANGUAGES, space="-"),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -53,6 +61,7 @@ CONFIG_SCHEMA = cv.Schema(
 def to_code(config):
     # Use user-specified command set, default to EP_2200
     cg.add_define(COMMAND_SETS[config[CONF_COMMAND_SET]])
+    cg.add_define(LANGUAGES[config[CONF_LANGUAGE]])
 
     var = cg.new_Pvariable(config[CONF_ID])
     yield cg.register_component(var, config)

--- a/components/philips_coffee_machine/localization.h
+++ b/components/philips_coffee_machine/localization.h
@@ -1,0 +1,110 @@
+#pragma once
+#include <string>
+
+namespace esphome
+{
+    namespace philips_coffee_machine
+    {
+#if defined(PHILIPS_COFFEE_LANG_en_US)
+#define PHILIPS_COFFEE_LANG_DEFAULT
+#elif defined(PHILIPS_COFFEE_LANG_de_DE)
+        const std::string state_unknown = "Unbekannt";
+        const std::string state_off = "Aus";
+        const std::string state_idle = "Bereit";
+        const std::string state_cleaning = "Spült";
+        const std::string state_preparing = "Vorbereitung";
+        const std::string state_water_empty = "Wasser leer";
+        const std::string state_waste_warning = "Abfallcontainerwarnung";
+        const std::string state_error = "Fehler";
+
+        const std::string state_ground_coffee_selected = "Vorgemahlener Kaffee ausgewählt";
+        const std::string state_coffee_programming_mode = "Kaffee Programmiermodus ausgewählt";
+        const std::string state_coffee_selected = "Kaffee ausgewählt";
+        const std::string state_coffee_2x_selected = "2x Kaffee ausgewählt";
+        const std::string state_coffee_brewing = "Bereitet Kaffee zu";
+        const std::string state_coffee_2x_brewing = "Bereitet 2x Kaffee zu";
+
+        const std::string state_ground_espresso_selected = "Vorgemahlener Espresso ausgewählt";
+        const std::string state_espresso_programming_mode = "Espresso Programmiermodus ausgewählt";
+        const std::string state_espresso_selected = "Espresso ausgewählt";
+        const std::string state_espresso_2x_selected = "2x Espresso ausgewählt";
+        const std::string state_espresso_brewing = "Bereitet Espresso zu";
+        const std::string state_espresso_2x_brewing = "Bereitet 2x Espresso zu";
+
+        const std::string state_ground_americano_selected = "Vorgemahlener Americano ausgewählt";
+        const std::string state_americano_programming_mode = "Americano Programmiermodus ausgewählt";
+        const std::string state_americano_selected = "Americano ausgewählt";
+        const std::string state_americano_2x_selected = "2x Americano ausgewählt";
+        const std::string state_americano_brewing = "Bereitet Americano zu";
+        const std::string state_americano_2x_brewing = "Bereitet 2x Americano zu";
+
+        const std::string state_ground_cappuccino_selected = "Vorgemahlener Cappuccino ausgewählt";
+        const std::string state_cappuccino_programming_mode = "Cappuccino Programmiermodus ausgewählt";
+        const std::string state_cappuccino_selected = "Cappuccino ausgewählt";
+        const std::string state_cappuccino_brewing = "Bereitet Cappuccino zu";
+
+        const std::string state_ground_latte_selected = "Vorgemahlener Latte macchiato ausgewählt";
+        const std::string state_latte_programming_mode = "Latte macchiato Programmiermodus ausgewählt";
+        const std::string state_latte_selected = "Latte macchiato ausgewählt";
+        const std::string state_latte_brewing = "Bereitet Latte macchiato zu";
+
+        const std::string state_hot_water_programming_mode = "Heißes Wasser Programmiermodus ausgewählt";
+        const std::string state_hot_water_selected = "Heißes Wasser ausgewählt";
+        const std::string state_hot_water_brewing = "Bereitet heißes Wasser zu";
+
+        const std::string state_steam_selected = "Dampf ausgewählt";
+        const std::string state_steam_brewing = "Bereitet Dampf zu";
+#else
+#define PHILIPS_COFFEE_LANG_DEFAULT
+#endif
+
+#ifdef PHILIPS_COFFEE_LANG_DEFAULT
+        const std::string state_unknown = "Unknown";
+        const std::string state_off = "Off";
+        const std::string state_idle = "Idle";
+        const std::string state_cleaning = "Cleaning";
+        const std::string state_preparing = "Preparing";
+        const std::string state_water_empty = "Water empty";
+        const std::string state_waste_warning = "Waste container warning";
+        const std::string state_error = "Error";
+
+        const std::string state_ground_coffee_selected = "Pre-ground Coffee selected";
+        const std::string state_coffee_programming_mode = "Coffee programming mode selected";
+        const std::string state_coffee_selected = "Coffee selected";
+        const std::string state_coffee_2x_selected = "2x Coffee selected";
+        const std::string state_coffee_brewing = "Brewing Coffee";
+        const std::string state_coffee_2x_brewing = "Brewing 2x Coffee";
+
+        const std::string state_ground_espresso_selected = "Pre-ground Espresso selected";
+        const std::string state_espresso_programming_mode = "Espresso programming mode selected";
+        const std::string state_espresso_selected = "Espresso selected";
+        const std::string state_espresso_2x_selected = "2x Espresso selected";
+        const std::string state_espresso_brewing = "Brewing Espresso";
+        const std::string state_espresso_2x_brewing = "Brewing 2x Espresso";
+
+        const std::string state_ground_americano_selected = "Pre-ground Americano selected";
+        const std::string state_americano_programming_mode = "Americano programming mode selected";
+        const std::string state_americano_selected = "Americano selected";
+        const std::string state_americano_2x_selected = "2x Americano selected";
+        const std::string state_americano_brewing = "Brewing Americano";
+        const std::string state_americano_2x_brewing = "Brewing 2x Americano";
+
+        const std::string state_ground_cappuccino_selected = "Pre-ground Cappuccino selected";
+        const std::string state_cappuccino_programming_mode = "Cappuccino programming mode selected";
+        const std::string state_cappuccino_selected = "Cappuccino selected";
+        const std::string state_cappuccino_brewing = "Brewing Cappuccino";
+
+        const std::string state_ground_latte_selected = "Pre-ground Latte Macchiato selected";
+        const std::string state_latte_programming_mode = "Latte Macchiato programming mode selected";
+        const std::string state_latte_selected = "Latte Macchiato selected";
+        const std::string state_latte_brewing = "Brewing Latte Macchiato";
+
+        const std::string state_hot_water_programming_mode = "Hot water programming mode selected";
+        const std::string state_hot_water_selected = "Hot water selected";
+        const std::string state_hot_water_brewing = "Making Hot Water";
+
+        const std::string state_steam_selected = "Steam selected";
+        const std::string state_steam_brewing = "Making Steam";
+#endif
+    } // namespace philips_coffee_machine
+} // namespace esphome

--- a/components/philips_coffee_machine/number/beverage_setting.cpp
+++ b/components/philips_coffee_machine/number/beverage_setting.cpp
@@ -35,25 +35,25 @@ namespace esphome
                 // only apply status if source is currently selected
                 std::string status = status_sensor_->get_raw_state();
                 if ((type_ != MILK && (source_ == COFFEE || source_ == ANY) &&
-                     (status.compare("Coffee selected") == 0 ||
-                      status.compare("2x Coffee selected") == 0 ||
-                      (type_ != BEAN && status.compare("Ground Coffee selected") == 0))) ||
+                     (status.compare(state_coffee_selected) == 0 ||
+                      status.compare(state_coffee_2x_selected) == 0 ||
+                      (type_ != BEAN && status.compare(state_ground_coffee_selected) == 0))) ||
                     (type_ != MILK && (source_ == ESPRESSO || source_ == ANY) &&
-                     (status.compare("Espresso selected") == 0 ||
-                      status.compare("2x Espresso selected") == 0 ||
-                      (type_ != BEAN && status.compare("Ground Espresso selected") == 0))) ||
+                     (status.compare(state_espresso_selected) == 0 ||
+                      status.compare(state_espresso_2x_selected) == 0 ||
+                      (type_ != BEAN && status.compare(state_ground_espresso_selected) == 0))) ||
                     (type_ != MILK && (source_ == AMERICANO || source_ == ANY) &&
-                     (status.compare("Americano selected") == 0 ||
-                      status.compare("2x Americano selected") == 0 ||
-                      (type_ != BEAN && status.compare("Ground Americano selected") == 0))) ||
+                     (status.compare(state_americano_selected) == 0 ||
+                      status.compare(state_americano_2x_selected) == 0 ||
+                      (type_ != BEAN && status.compare(state_ground_americano_selected) == 0))) ||
                     ((source_ == CAPPUCCINO || source_ == ANY) &&
-                     (status.compare("Cappuccino selected") == 0 ||
-                      (type_ != BEAN && status.compare("Ground Cappuccino selected") == 0))) ||
+                     (status.compare(state_cappuccino_selected) == 0 ||
+                      (type_ != BEAN && status.compare(state_ground_cappuccino_selected) == 0))) ||
                     ((source_ == LATTE_MACCHIATO || source_ == ANY) &&
-                     (status.compare("Latte Macchiato selected") == 0 ||
-                      (type_ != BEAN && status.compare("Ground Latte Macchiato selected") == 0))) ||
+                     (status.compare(state_latte_selected) == 0 ||
+                      (type_ != BEAN && status.compare(state_ground_latte_selected) == 0))) ||
                     (type_ != BEAN && type_ != MILK && (source_ == HOT_WATER || source_ == ANY) &&
-                     status.compare("Hot water selected") == 0))
+                     status.compare(state_hot_water_selected) == 0))
                 {
                     uint8_t enable_byte = type_ == BEAN ? 9 : 11;
                     uint8_t amount_byte = type_ == BEAN ? 8 : (type_ == SIZE ? 10 : 13);

--- a/components/philips_coffee_machine/text_sensor/status_sensor.cpp
+++ b/components/philips_coffee_machine/text_sensor/status_sensor.cpp
@@ -50,7 +50,7 @@ namespace esphome
                     // This can be circumvented: if the user is on the selection screen/idle we can reset the timer
                     play_pause_last_change_ = millis();
 
-                    update_state("Idle");
+                    update_state(state_idle);
                     return;
                 }
 
@@ -61,30 +61,30 @@ namespace esphome
                 if (data[3] == led_half || data[4] == led_half || data[5] == led_half || data[6] == led_half)
                 {
                     if (play_pause_led_)
-                        update_state("Cleaning");
+                        update_state(state_cleaning);
                     else
-                        update_state("Preparing");
+                        update_state(state_preparing);
                     return;
                 }
 
                 // Water empty led
                 if (data[14] == led_second)
                 {
-                    update_state("Water empty");
+                    update_state(state_water_empty);
                     return;
                 }
 
                 // Waste container led
                 if (data[15] == led_on)
                 {
-                    update_state("Waste container warning");
+                    update_state(state_waste_warning);
                     return;
                 }
 
                 // Warning/Error led
                 if (data[15] == led_second)
                 {
-                    update_state("Error");
+                    update_state(state_error);
                     return;
                 }
 
@@ -95,20 +95,20 @@ namespace esphome
                     {
                         if (data[9] == led_second)
                         {
-                            update_state("Ground Coffee selected");
+                            update_state(state_ground_coffee_selected);
                         }
                         else if (data[11] == led_off && show_size_changed_recently)
                         {
-                            update_state("Coffee programming mode selected");
+                            update_state(state_coffee_programming_mode);
                         }
                         else
                         {
-                            update_state((data[5] == led_on) ? "Coffee selected" : "2x Coffee selected");
+                            update_state((data[5] == led_on) ? state_coffee_selected : state_coffee_2x_selected);
                         }
                     }
                     else
                     {
-                        update_state((data[5] == led_on) ? "Brewing Coffee" : "Brewing 2x Coffee");
+                        update_state((data[5] == led_on) ? state_coffee_brewing : state_coffee_2x_brewing);
                     }
                     return;
                 }
@@ -121,45 +121,45 @@ namespace esphome
                     {
                         if (data[9] == led_second)
                         {
-                            update_state("Ground Cappuccino selected");
+                            update_state(state_ground_cappuccino_selected);
                         }
                         else if (data[11] == led_off && show_size_changed_recently)
                         {
-                            update_state("Cappuccino programming mode selected");
+                            update_state(state_cappuccino_programming_mode);
                         }
                         else
                         {
-                            update_state("Cappuccino selected");
+                            update_state(state_cappuccino_selected);
                         }
                     }
                     else
                     {
-                        update_state("Brewing Cappuccino");
+                        update_state(state_cappuccino_brewing);
                     }
 #elif defined(PHILIPS_EP3243)
                     if (is_play_pause_blinking)
                     {
                         if (data[11] == led_off && show_size_changed_recently)
                         {
-                            update_state("Latte Macchiato programming mode selected");
+                            update_state(state_latte_programming_mode);
                         }
                         else
                         {
-                            update_state(data[9] == led_second ? "Ground Latte Macchiato selected" : "Latte Macchiato selected");
+                            update_state(data[9] == led_second ? state_ground_latte_selected : state_latte_selected);
                         }
                     }
                     else
                     {
-                        update_state("Brewing Latte Macchiato");
+                        update_state(state_latte_brewing);
                     }
 #else
                     if (is_play_pause_blinking)
                     {
-                        update_state("Steam selected");
+                        update_state(state_steam_selected);
                     }
                     else
                     {
-                        update_state("Making Steam");
+                        update_state(state_steam_brewing);
                     }
 #endif
                     return;
@@ -176,16 +176,16 @@ namespace esphome
                     {
                         if (data[11] == led_off && show_size_changed_recently)
                         {
-                            update_state("Hot water programming mode selected");
+                            update_state(state_hot_water_programming_mode);
                         }
                         else
                         {
-                            update_state("Hot water selected");
+                            update_state(state_hot_water_selected);
                         }
                     }
                     else
                     {
-                        update_state("Making Hot Water");
+                        update_state(state_hot_water_brewing);
                     }
                     return;
                 }
@@ -197,20 +197,20 @@ namespace esphome
                     {
                         if (data[9] == led_second)
                         {
-                            update_state("Ground Espresso selected");
+                            update_state(state_ground_espresso_selected);
                         }
                         else if (data[11] == led_off && show_size_changed_recently)
                         {
-                            update_state("Espresso programming mode selected");
+                            update_state(state_espresso_programming_mode);
                         }
                         else
                         {
-                            update_state((data[3] == led_on) ? "Espresso selected" : "2x Espresso selected");
+                            update_state((data[3] == led_on) ? state_espresso_selected : state_espresso_2x_selected);
                         }
                     }
                     else
                     {
-                        update_state((data[3] == led_on) ? "Brewing Espresso" : "Brewing 2x Espresso");
+                        update_state((data[3] == led_on) ? state_espresso_brewing : state_espresso_2x_brewing);
                     }
                     return;
                 }
@@ -223,16 +223,16 @@ namespace esphome
                     {
                         if (data[11] == led_off && show_size_changed_recently)
                         {
-                            update_state("Cappuccino programming mode selected");
+                            update_state(state_cappuccino_programming_mode);
                         }
                         else
                         {
-                            update_state(data[9] == led_second ? "Ground Cappuccino selected" : "Cappuccino selected");
+                            update_state(data[9] == led_second ? state_ground_cappuccino_selected : state_cappuccino_selected);
                         }
                     }
                     else
                     {
-                        update_state("Brewing Cappuccino");
+                        update_state(state_cappuccino_brewing);
                     }
                     return;
                 }
@@ -244,20 +244,20 @@ namespace esphome
                     {
                         if (data[9] == led_second)
                         {
-                            update_state("Ground Americano selected");
+                            update_state(state_ground_americano_selected);
                         }
                         else if (data[11] == led_off && show_size_changed_recently)
                         {
-                            update_state("Americano programming mode selected");
+                            update_state(state_americano_programming_mode);
                         }
                         else
                         {
-                            update_state((data[6] == led_second) ? "Americano selected" : "2x Americano selected");
+                            update_state((data[6] == led_second) ? state_americano_selected : state_americano_2x_selected);
                         }
                     }
                     else
                     {
-                        update_state((data[6] == led_second) ? "Brewing Americano" : "Brewing 2x Americano");
+                        update_state((data[6] == led_second) ? state_americano_brewing : state_americano_2x_brewing);
                     }
                     return;
                 }

--- a/components/philips_coffee_machine/text_sensor/status_sensor.h
+++ b/components/philips_coffee_machine/text_sensor/status_sensor.h
@@ -76,6 +76,9 @@ namespace esphome
 
                 /// @brief time of play/pause change
                 uint32_t play_pause_last_change_ = 0;
+
+                /// @brief time of the last enable size led change
+                uint32_t show_size_led_last_change_ = 0;
             };
         } // namespace philips_status_sensor
     }     // namespace philips_coffee_machine

--- a/components/philips_coffee_machine/text_sensor/status_sensor.h
+++ b/components/philips_coffee_machine/text_sensor/status_sensor.h
@@ -4,6 +4,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 #include "../commands.h"
+#include "../localization.h"
 
 // Feel free to lower this, you might get some invalid intermittent state though
 #define REPEAT_REQUIREMENT 30
@@ -35,8 +36,8 @@ namespace esphome
                  */
                 void set_state_off()
                 {
-                    if (state != "Off")
-                        publish_state("Off");
+                    if (state != state_off)
+                        publish_state(state_off);
                 };
 
                 /**
@@ -69,7 +70,7 @@ namespace esphome
                 int new_state_counter_ = 0;
 
                 /// @brief cache for counting new messages
-                std::string new_state_ = "";
+                std::string new_state_ = state_unknown;
 
                 /// @brief status of the play/pause led
                 bool play_pause_led_ = false;


### PR DESCRIPTION
This PR adds localization and internationalization support.
The status sensor can now provide updates in different languages. Currently supported languages include English(`en-US`) and German(`de-DE`).
Furthermore, the `Busy` state has been replaced with beverage-specific states such as "Brewing Coffee" (Breaking change).

Close #38