### PR TITLE
Fix EP32xx state detection

### DIFF
--- a/components/philips_coffee_machine/text_sensor/status_sensor.cpp
+++ b/components/philips_coffee_machine/text_sensor/status_sensor.cpp
@@ -114,7 +114,7 @@ namespace esphome
                 }
 
                 // Steam selected
-                if (data[3] == led_off && data[4] == led_off && data[5] == led_off && data[6] != led_off)
+                if (data[3] == led_off && data[4] == led_off && data[5] == led_off && (data[6] == led_on || data[6] == led_third))
                 {
 #ifdef PHILIPS_EP2235
                     if (is_play_pause_blinking)


### PR DESCRIPTION
This PR fixes an issue on EP32xx machines which was introduced by #45.

Try this PR using:

```yaml
external_components:
  - source: github://TillFleisch/ESPHome-Philips-Smart-Coffee@fix_EP3243_state_detection
    refresh: 30min
```

Close #60 